### PR TITLE
Fixed Eslint parentheses bug

### DIFF
--- a/src/components/TwoDice.tsx
+++ b/src/components/TwoDice.tsx
@@ -31,15 +31,8 @@ export function TwoDice(): JSX.Element {
             <Button onClick={() => rollDice(1)}>Roll Left</Button>
             <Button onClick={() => rollDice(2)}>Roll Right</Button>
 
-            {dice1 === dice2 ? (
-                dice1 === 1 ? (
-                    <span>Lose</span>
-                ) : (
-                    <span>Win</span>
-                )
-            ) : (
-                ""
-            )}
+            {dice1 === dice2 && dice1 !== 1 ? "Win" : ""}
+            {dice1 === dice2 && dice1 === 1 ? "Lose" : ""}
         </div>
     );
 }


### PR DESCRIPTION
Split display of "Win" or "Lose" in TwoDice Component into two separate ternaries as EsLint was bugging out with the parentheses.